### PR TITLE
Add WTFPL license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                   Version 2, December 2004
+ 
+Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+Everyone is permitted to copy and distribute verbatim or modified
+copies of this license document, and changing it is allowed as long
+as the name is changed.
+ 
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+  TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+ 0. You just DO WHAT THE FUCK YOU WANT TO.


### PR DESCRIPTION
The GPL license doesn't seem applicable, so the WTFPL license was chosen.

If the GPL license is preferred, an extra clause exempting users from needing to provide the source of the Unity engine would need added. (See: https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs)

It would look something like this for version 3.0 of the license:

"If you modify this Program, or any covered work, by linking or combining it with [Unity](https://unity3d.com) (or a modified version of that library), containing parts covered by the terms of [Unity's license](https://unity3d.com/legal/terms-of-service), the licensors of this Program grant you additional permission to convey the resulting work. {Corresponding Source for a non-source form of such a combination shall include the source code for the parts of [Unity](https://unity3d.com) used as well as that of the covered work.}"